### PR TITLE
Enabling breakpoints with using path module to resolve paths correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ jspm_packages
 # Project specific
 temp/*
 !temp/.gitkeep
+
+*.map

--- a/dist/main/alexa-voice-service/audio-service.js
+++ b/dist/main/alexa-voice-service/audio-service.js
@@ -60,3 +60,4 @@ class AudioService {
     }
 }
 exports.AudioService = AudioService;
+//# sourceMappingURL=audio-service.js.map

--- a/dist/main/alexa-voice-service/audio-service.js
+++ b/dist/main/alexa-voice-service/audio-service.js
@@ -2,12 +2,12 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 // Reference: https://developer.amazon.com/public/solutions/alexa/alexa-voice-service/rest/speechrecognizer-recognize-request
 const fs = require("fs");
-const request = require("request");
 const path = require("path");
+const request = require("request");
 const url = "https://access-alexa-na.amazon.com/v1/avs/speechrecognizer/recognize";
 class AudioService {
     sendAudio(token, file) {
-        const stream = fs.createWriteStream(path.resolve(__dirname, '../../../temp/output.mpeg'));
+        const stream = fs.createWriteStream(path.resolve(__dirname, "../../../temp/output.mpeg"));
         return new Promise((resolve, reject) => {
             request.post({
                 uri: url,
@@ -49,7 +49,7 @@ class AudioService {
             }).pipe(stream);
             stream.on("finish", () => {
                 if (stream.bytesWritten === 0) {
-                    fs.unlink(path.resolve(__dirname, '../../../temp/output.mpeg'), () => {
+                    fs.unlink(path.resolve(__dirname, "../../../temp/output.mpeg"), () => {
                         resolve();
                     });
                     return;

--- a/dist/main/alexa-voice-service/audio-service.js
+++ b/dist/main/alexa-voice-service/audio-service.js
@@ -3,10 +3,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 // Reference: https://developer.amazon.com/public/solutions/alexa/alexa-voice-service/rest/speechrecognizer-recognize-request
 const fs = require("fs");
 const request = require("request");
+const path = require("path");
 const url = "https://access-alexa-na.amazon.com/v1/avs/speechrecognizer/recognize";
 class AudioService {
     sendAudio(token, file) {
-        const stream = fs.createWriteStream(`${process.env.CWD}/temp/output.mpeg`);
+        const stream = fs.createWriteStream(path.resolve(__dirname, '../../../temp/output.mpeg'));
         return new Promise((resolve, reject) => {
             request.post({
                 uri: url,
@@ -48,7 +49,7 @@ class AudioService {
             }).pipe(stream);
             stream.on("finish", () => {
                 if (stream.bytesWritten === 0) {
-                    fs.unlink(`${process.env.CWD}/temp/output.mpeg`, () => {
+                    fs.unlink(path.resolve(__dirname, '../../../temp/output.mpeg'), () => {
                         resolve();
                     });
                     return;

--- a/dist/main/alexa-voice-service/avs-options.js
+++ b/dist/main/alexa-voice-service/avs-options.js
@@ -1,2 +1,3 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+//# sourceMappingURL=avs-options.js.map

--- a/dist/main/alexa-voice-service/index.js
+++ b/dist/main/alexa-voice-service/index.js
@@ -4,3 +4,4 @@ var audio_service_1 = require("./audio-service");
 exports.AudioService = audio_service_1.AudioService;
 var token_service_1 = require("./token-service");
 exports.TokenService = token_service_1.TokenService;
+//# sourceMappingURL=index.js.map

--- a/dist/main/alexa-voice-service/token-service.js
+++ b/dist/main/alexa-voice-service/token-service.js
@@ -51,3 +51,4 @@ class TokenService {
     }
 }
 exports.TokenService = TokenService;
+//# sourceMappingURL=token-service.js.map

--- a/dist/main/config-service.js
+++ b/dist/main/config-service.js
@@ -9,3 +9,4 @@ class ConfigService {
     }
 }
 exports.ConfigService = ConfigService;
+//# sourceMappingURL=config-service.js.map

--- a/dist/main/detector.js
+++ b/dist/main/detector.js
@@ -1,12 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+const path = require("path");
 const Rx_1 = require("rxjs/Rx");
 const snowboy_1 = require("snowboy");
-const path = require("path");
 class HotwordDetector extends snowboy_1.Detector {
     constructor(models) {
         super({
-            resource: path.resolve(__dirname, '../../resources/common.res'),
+            resource: path.resolve(__dirname, "../../resources/common.res"),
             models: models,
             audioGain: 2.0,
         });

--- a/dist/main/detector.js
+++ b/dist/main/detector.js
@@ -37,3 +37,4 @@ class HotwordDetector extends snowboy_1.Detector {
     }
 }
 exports.HotwordDetector = HotwordDetector;
+//# sourceMappingURL=detector.js.map

--- a/dist/main/detector.js
+++ b/dist/main/detector.js
@@ -2,10 +2,11 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const Rx_1 = require("rxjs/Rx");
 const snowboy_1 = require("snowboy");
+const path = require("path");
 class HotwordDetector extends snowboy_1.Detector {
     constructor(models) {
         super({
-            resource: `${process.env.CWD}/resources/common.res`,
+            resource: path.resolve(__dirname, '../../resources/common.res'),
             models: models,
             audioGain: 2.0,
         });

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -68,3 +68,4 @@ class Main {
 }
 exports.default = Main;
 module.exports = Main;
+//# sourceMappingURL=index.js.map

--- a/dist/main/models/index.js
+++ b/dist/main/models/index.js
@@ -2,3 +2,4 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 var models_1 = require("./models");
 exports.AlexaModels = models_1.AlexaModels;
+//# sourceMappingURL=index.js.map

--- a/dist/main/models/model-dictionary.js
+++ b/dist/main/models/model-dictionary.js
@@ -19,3 +19,4 @@ const MODELS = {
     },
 };
 exports.MODELS = MODELS;
+//# sourceMappingURL=model-dictionary.js.map

--- a/dist/main/models/models.js
+++ b/dist/main/models/models.js
@@ -19,3 +19,4 @@ class AlexaModels extends snowboy_1.Models {
     }
 }
 exports.AlexaModels = AlexaModels;
+//# sourceMappingURL=models.js.map

--- a/dist/main/models/models.js
+++ b/dist/main/models/models.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const snowboy_1 = require("snowboy");
 const path = require("path");
+const snowboy_1 = require("snowboy");
 const model_dictionary_1 = require("./model-dictionary");
 class AlexaModels extends snowboy_1.Models {
     constructor(wakeWord) {
@@ -12,7 +12,7 @@ class AlexaModels extends snowboy_1.Models {
             model = model_dictionary_1.MODELS.Alexa;
         }
         this.add({
-            file: path.resolve(__dirname, '../../../resources/models', model.file),
+            file: path.resolve(__dirname, "../../../resources/models", model.file),
             sensitivity: "0.5",
             hotwords: model.name,
         });

--- a/dist/main/models/models.js
+++ b/dist/main/models/models.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const snowboy_1 = require("snowboy");
+const path = require("path");
 const model_dictionary_1 = require("./model-dictionary");
 class AlexaModels extends snowboy_1.Models {
     constructor(wakeWord) {
@@ -11,7 +12,7 @@ class AlexaModels extends snowboy_1.Models {
             model = model_dictionary_1.MODELS.Alexa;
         }
         this.add({
-            file: `${process.env.CWD}/resources/models/${model.file}`,
+            file: path.resolve(__dirname, '../../../resources/models', model.file),
             sensitivity: "0.5",
             hotwords: model.name,
         });

--- a/dist/main/rec-tester.js
+++ b/dist/main/rec-tester.js
@@ -11,3 +11,4 @@ class RecTester {
     }
 }
 exports.RecTester = RecTester;
+//# sourceMappingURL=rec-tester.js.map

--- a/dist/main/renderer-communicator.js
+++ b/dist/main/renderer-communicator.js
@@ -13,3 +13,4 @@ class RendererCommunicator {
     }
 }
 exports.RendererCommunicator = RendererCommunicator;
+//# sourceMappingURL=renderer-communicator.js.map

--- a/dist/main/states/alexa-state-machine.js
+++ b/dist/main/states/alexa-state-machine.js
@@ -19,3 +19,4 @@ class AlexaStateMachine {
     }
 }
 exports.AlexaStateMachine = AlexaStateMachine;
+//# sourceMappingURL=alexa-state-machine.js.map

--- a/dist/main/states/base.state.js
+++ b/dist/main/states/base.state.js
@@ -23,3 +23,4 @@ class State {
     }
 }
 exports.State = State;
+//# sourceMappingURL=base.state.js.map

--- a/dist/main/states/busy.state.js
+++ b/dist/main/states/busy.state.js
@@ -28,3 +28,4 @@ class BusyState extends base_state_1.State {
     }
 }
 exports.BusyState = BusyState;
+//# sourceMappingURL=busy.state.js.map

--- a/dist/main/states/busy.state.js
+++ b/dist/main/states/busy.state.js
@@ -9,7 +9,7 @@ class BusyState extends base_state_1.State {
     }
     onEnter() {
         this.components.rendererSend("busy", {});
-        const readStream = fs.createReadStream(path.resolve(__dirname, '../../../temp/to-amazon.wav'));
+        const readStream = fs.createReadStream(path.resolve(__dirname, "../../../temp/to-amazon.wav"));
         const accessToken = this.components.configService.Config.accessToken;
         this.components.audioService.sendAudio(accessToken, readStream).then((result) => {
             this.components.rendererSend("speak", {});

--- a/dist/main/states/busy.state.js
+++ b/dist/main/states/busy.state.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs");
+const path = require("path");
 const base_state_1 = require("./base.state");
 class BusyState extends base_state_1.State {
     constructor(components) {
@@ -8,7 +9,7 @@ class BusyState extends base_state_1.State {
     }
     onEnter() {
         this.components.rendererSend("busy", {});
-        const readStream = fs.createReadStream(`${process.env.CWD}/temp/to-amazon.wav`);
+        const readStream = fs.createReadStream(path.resolve(__dirname, '../../../temp/to-amazon.wav'));
         const accessToken = this.components.configService.Config.accessToken;
         this.components.audioService.sendAudio(accessToken, readStream).then((result) => {
             this.components.rendererSend("speak", {});

--- a/dist/main/states/idle.state.js
+++ b/dist/main/states/idle.state.js
@@ -33,3 +33,4 @@ class IdleState extends base_state_1.State {
     }
 }
 exports.IdleState = IdleState;
+//# sourceMappingURL=idle.state.js.map

--- a/dist/main/states/listening.state.js
+++ b/dist/main/states/listening.state.js
@@ -10,7 +10,7 @@ class ListeningState extends base_state_1.State {
     }
     onEnter() {
         this.components.rendererSend("listening", {});
-        const writeStream = fs.createWriteStream(path.resolve(__dirname, '../../../temp/to-amazon.wav'));
+        const writeStream = fs.createWriteStream(path.resolve(__dirname, "../../../temp/to-amazon.wav"));
         writeStream.on("finish", () => {
             this.transition(this.allowedStateTransitions.get("busy"));
         });

--- a/dist/main/states/listening.state.js
+++ b/dist/main/states/listening.state.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs");
 const record = require("node-record-lpcm16");
+const path = require("path");
 const base_state_1 = require("./base.state");
 class ListeningState extends base_state_1.State {
     constructor(components) {
@@ -9,7 +10,7 @@ class ListeningState extends base_state_1.State {
     }
     onEnter() {
         this.components.rendererSend("listening", {});
-        const writeStream = fs.createWriteStream(`${process.env.CWD}/temp/to-amazon.wav`);
+        const writeStream = fs.createWriteStream(path.resolve(__dirname, '../../../temp/to-amazon.wav'));
         writeStream.on("finish", () => {
             this.transition(this.allowedStateTransitions.get("busy"));
         });

--- a/dist/main/states/listening.state.js
+++ b/dist/main/states/listening.state.js
@@ -28,3 +28,4 @@ class ListeningState extends base_state_1.State {
     }
 }
 exports.ListeningState = ListeningState;
+//# sourceMappingURL=listening.state.js.map

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,24 +1,23 @@
 const fs = require("fs");
 const NodeHelper = require("node_helper");
 const Main = require("./dist/main");
+const path = require("path");
 
 let main;
-
-process.env.CWD = `${process.env.PWD}/modules/MMM-awesome-alexa`;
 
 module.exports = NodeHelper.create({
     start: function () {
         this.expressApp.get("/output.mpeg", function (req, res) {
             res.setHeader("Expires", new Date().toUTCString());
-            const path = `${process.env.CWD}/temp/output.mpeg`;
+            const outputPath = path.resolve(__dirname, 'temp/output.mpeg');
 
-            if (!fs.existsSync(path)) {
-                const rstream = fs.createReadStream(`${process.env.CWD}/resources/alexa/sorry-im-not-sure.mpeg`);
+            if (!fs.existsSync(outputPath)) {
+                const rstream = fs.createReadStream(path.resolve(__dirname, 'resources/alexa/sorry-im-not-sure.mpeg'));
                 rstream.pipe(res);
                 return;
             }
 
-            const rstream = fs.createReadStream(path);
+            const rstream = fs.createReadStream(outputPath);
             rstream.pipe(res);
         });
     },

--- a/src/main/alexa-voice-service/audio-service.ts
+++ b/src/main/alexa-voice-service/audio-service.ts
@@ -1,12 +1,13 @@
 // Reference: https://developer.amazon.com/public/solutions/alexa/alexa-voice-service/rest/speechrecognizer-recognize-request
 import * as fs from "fs";
 import * as request from "request";
+import * as path from "path";
 
 const url = "https://access-alexa-na.amazon.com/v1/avs/speechrecognizer/recognize";
 
 export class AudioService {
     public sendAudio(token: string, file: fs.ReadStream): Promise<void> {
-        const stream = fs.createWriteStream(`${process.env.CWD}/temp/output.mpeg`);
+        const stream = fs.createWriteStream(path.resolve(__dirname, '../../../temp/output.mpeg'));
 
         return new Promise<void>((resolve, reject) => {
 
@@ -52,7 +53,7 @@ export class AudioService {
 
             stream.on("finish", () => {
                 if (stream.bytesWritten === 0) {
-                    fs.unlink(`${process.env.CWD}/temp/output.mpeg`, () => {
+                    fs.unlink(path.resolve(__dirname, '../../../temp/output.mpeg'), () => {
                         resolve();
                     });
                     return;

--- a/src/main/alexa-voice-service/audio-service.ts
+++ b/src/main/alexa-voice-service/audio-service.ts
@@ -1,13 +1,13 @@
 // Reference: https://developer.amazon.com/public/solutions/alexa/alexa-voice-service/rest/speechrecognizer-recognize-request
 import * as fs from "fs";
-import * as request from "request";
 import * as path from "path";
+import * as request from "request";
 
 const url = "https://access-alexa-na.amazon.com/v1/avs/speechrecognizer/recognize";
 
 export class AudioService {
     public sendAudio(token: string, file: fs.ReadStream): Promise<void> {
-        const stream = fs.createWriteStream(path.resolve(__dirname, '../../../temp/output.mpeg'));
+        const stream = fs.createWriteStream(path.resolve(__dirname, "../../../temp/output.mpeg"));
 
         return new Promise<void>((resolve, reject) => {
 
@@ -53,7 +53,7 @@ export class AudioService {
 
             stream.on("finish", () => {
                 if (stream.bytesWritten === 0) {
-                    fs.unlink(path.resolve(__dirname, '../../../temp/output.mpeg'), () => {
+                    fs.unlink(path.resolve(__dirname, "../../../temp/output.mpeg"), () => {
                         resolve();
                     });
                     return;

--- a/src/main/detector.ts
+++ b/src/main/detector.ts
@@ -1,5 +1,6 @@
 import { Observable, Subject } from "rxjs/Rx";
 import { Detector, Models } from "snowboy";
+import * as path from "path";
 
 export class HotwordDetector extends Detector {
     private subject: Subject<DETECTOR>;
@@ -8,7 +9,7 @@ export class HotwordDetector extends Detector {
 
     constructor(models: Models) {
         super({
-            resource: `${process.env.CWD}/resources/common.res`,
+            resource: path.resolve(__dirname, '../../resources/common.res'),
             models: models,
             audioGain: 2.0,
         });

--- a/src/main/detector.ts
+++ b/src/main/detector.ts
@@ -1,6 +1,6 @@
+import * as path from "path";
 import { Observable, Subject } from "rxjs/Rx";
 import { Detector, Models } from "snowboy";
-import * as path from "path";
 
 export class HotwordDetector extends Detector {
     private subject: Subject<DETECTOR>;
@@ -9,7 +9,7 @@ export class HotwordDetector extends Detector {
 
     constructor(models: Models) {
         super({
-            resource: path.resolve(__dirname, '../../resources/common.res'),
+            resource: path.resolve(__dirname, "../../resources/common.res"),
             models: models,
             audioGain: 2.0,
         });

--- a/src/main/models/models.ts
+++ b/src/main/models/models.ts
@@ -1,5 +1,5 @@
-import { Models } from "snowboy";
 import * as path from "path";
+import { Models } from "snowboy";
 
 import { MODELS } from "./model-dictionary";
 
@@ -14,7 +14,7 @@ export class AlexaModels extends Models {
         }
 
         this.add({
-            file: path.resolve(__dirname, '../../../resources/models', model.file),
+            file: path.resolve(__dirname, "../../../resources/models", model.file),
             sensitivity: "0.5",
             hotwords: model.name,
         });

--- a/src/main/models/models.ts
+++ b/src/main/models/models.ts
@@ -1,4 +1,5 @@
 import { Models } from "snowboy";
+import * as path from "path";
 
 import { MODELS } from "./model-dictionary";
 
@@ -13,7 +14,7 @@ export class AlexaModels extends Models {
         }
 
         this.add({
-            file: `${process.env.CWD}/resources/models/${model.file}`,
+            file: path.resolve(__dirname, '../../../resources/models', model.file),
             sensitivity: "0.5",
             hotwords: model.name,
         });

--- a/src/main/states/busy.state.ts
+++ b/src/main/states/busy.state.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import { Subscription } from "rxjs/Rx";
+import * as path from "path";
 
 import { IStateMachineComponents } from "./alexa-state-machine";
 import { State } from "./base.state";
@@ -13,7 +14,7 @@ export class BusyState extends State {
 
     public onEnter(): void {
         this.components.rendererSend("busy", {});
-        const readStream = fs.createReadStream(`${process.env.CWD}/temp/to-amazon.wav`);
+        const readStream = fs.createReadStream(path.resolve(__dirname, '../../../temp/to-amazon.wav'));
         const accessToken = this.components.configService.Config.accessToken;
 
         this.components.audioService.sendAudio(accessToken, readStream).then((result) => {

--- a/src/main/states/busy.state.ts
+++ b/src/main/states/busy.state.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
-import { Subscription } from "rxjs/Rx";
 import * as path from "path";
+import { Subscription } from "rxjs/Rx";
 
 import { IStateMachineComponents } from "./alexa-state-machine";
 import { State } from "./base.state";
@@ -14,7 +14,7 @@ export class BusyState extends State {
 
     public onEnter(): void {
         this.components.rendererSend("busy", {});
-        const readStream = fs.createReadStream(path.resolve(__dirname, '../../../temp/to-amazon.wav'));
+        const readStream = fs.createReadStream(path.resolve(__dirname, "../../../temp/to-amazon.wav"));
         const accessToken = this.components.configService.Config.accessToken;
 
         this.components.audioService.sendAudio(accessToken, readStream).then((result) => {

--- a/src/main/states/listening.state.ts
+++ b/src/main/states/listening.state.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as record from "node-record-lpcm16";
-import { Subscription } from "rxjs/Rx";
 import * as path from "path";
+import { Subscription } from "rxjs/Rx";
 
 import { IStateMachineComponents } from "./alexa-state-machine";
 import { State } from "./base.state";
@@ -15,7 +15,7 @@ export class ListeningState extends State {
 
     public onEnter(): void {
         this.components.rendererSend("listening", {});
-        const writeStream = fs.createWriteStream(path.resolve(__dirname, '../../../temp/to-amazon.wav'));
+        const writeStream = fs.createWriteStream(path.resolve(__dirname, "../../../temp/to-amazon.wav"));
         writeStream.on("finish", () => {
             this.transition(this.allowedStateTransitions.get("busy"));
         });

--- a/src/main/states/listening.state.ts
+++ b/src/main/states/listening.state.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as record from "node-record-lpcm16";
 import { Subscription } from "rxjs/Rx";
+import * as path from "path";
 
 import { IStateMachineComponents } from "./alexa-state-machine";
 import { State } from "./base.state";
@@ -14,7 +15,7 @@ export class ListeningState extends State {
 
     public onEnter(): void {
         this.components.rendererSend("listening", {});
-        const writeStream = fs.createWriteStream(`${process.env.CWD}/temp/to-amazon.wav`);
+        const writeStream = fs.createWriteStream(path.resolve(__dirname, '../../../temp/to-amazon.wav'));
         writeStream.on("finish", () => {
             this.transition(this.allowedStateTransitions.get("busy"));
         });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": true,
-        "sourceMap": false,
+        "sourceMap": true,
         "outDir": "./dist",
         "declaration": false,
         "rootDir": "./src",


### PR DESCRIPTION
Using `process.env.CWD` has buggy side effects because many applications might have to switch the current working directory to another directory to fetch or serve different files. I noticed this when I wanted to add breaking points to the project with VScode.

Now with using `path` module everything works as it should and I can use breakpoints in the Typescript files 😼 

I can demo this if you are not familar with VScode debugging tool :)